### PR TITLE
fix: correct CV links and affiliation labels

### DIFF
--- a/src/Cv.js
+++ b/src/Cv.js
@@ -19,7 +19,7 @@ const Cv = () => (
             <wbr />
             2020/03
           </th>
-          <td><FormattedMessage id="affiliation" /></td>
+          <td><FormattedMessage id="affiliation.phd" /></td>
         </tr>
         <tr>
           <th>
@@ -71,7 +71,7 @@ const Cv = () => (
     <h3><FormattedMessage id="staff" /></h3>
     <ol reversed="reversed">
       <li>
-        <a href="https://www.ipsj.or.jp/sig/qs/" target="_blank" rel="noreferrer noopener">
+        <a href="https://sigqs.ipsj.or.jp/committee.html" target="_blank" rel="noreferrer noopener">
           <FormattedMessage id="ipsjqs" />
         </a>
       </li>

--- a/src/Header.js
+++ b/src/Header.js
@@ -9,7 +9,7 @@ const Header = () => (
         <FormattedMessage id="job.title" />
         ,
         {' '}
-        <FormattedMessage id="affiliation" />
+        <FormattedMessage id="header.affiliation" />
       </p>
     </a>
   </header>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1,6 +1,7 @@
 {
   "ikko.hamamura": "Ikko Hamamura",
-  "affiliation": "NVIDIA",
+  "header.affiliation": "NVIDIA",
+  "affiliation.phd": "Quantum Physics Group, Graduate School of Engineering, Kyoto University",
   "job.title": "Quantum Algorithm Engineer",
   "research.interest": "Research Interest",
   "quantum.information": "Quantum information",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -1,6 +1,7 @@
 {
   "ikko.hamamura": "濵村 一航",
-  "affiliation": "NVIDIA",
+  "header.affiliation": "NVIDIA",
+  "affiliation.phd": "京都大学大学院 工学研究科 量子物理学研究室",
   "job.title": "Quantum Algorithm Engineer",
   "research.interest": "研究の興味",
   "quantum.information": "量子情報",


### PR DESCRIPTION
## Summary
This PR fixes the wrong IPSJ link and resolves the confusion between the header affiliation and the education affiliation in the CV.

## Changes
- **IPSJ Link**: Updated to https://sigqs.ipsj.or.jp/committee.html.
- **Affiliation Keys**: Renamed the ambiguous 'affiliation' key to 'affiliation.phd' to ensure the Education section always shows the correct university department, regardless of the current header position.
- **Header**: Continues to use 'header.affiliation' for the short 'NVIDIA' display.